### PR TITLE
fix: correct curl flags

### DIFF
--- a/app/_includes/md/kic/http-test-routing.md
+++ b/app/_includes/md/kic/http-test-routing.md
@@ -12,7 +12,7 @@ Create routing configuration to proxy `{{ path }}` requests to the echo server:
 Test the routing rule:
 
 ```bash
-curl -i http://{{ hostname }}{{ path }} --resolve {{ hostname }}:80:$PROXY_IP
+curl -i http://{{ hostname }}{{ path }} --connect-to {{ hostname }}:80:${{PROXY_IP##http://}
 ```
 Response:
 ```text

--- a/app/_src/kubernetes-ingress-controller/guides/getting-started.md
+++ b/app/_src/kubernetes-ingress-controller/guides/getting-started.md
@@ -73,7 +73,7 @@ gateway.gateway.networking.k8s.io/kong patched
 After, requests will serve the configured certificate:
 
 ```bash
-curl -ksv https://kong.example/echo --resolve kong.example:443:$PROXY_IP 2>&1 | grep -A1 "certificate:"
+curl -ksv https://kong.example/echo --connect-to kong.example:443:${PROXY_IP##http://} 2>&1 | grep -A1 "certificate:"
 ```
 Response:
 ```text
@@ -127,7 +127,7 @@ Kong will now apply your plugin configuration to all routes associated with
 this resource. To test it, send another request through the proxy:
 
 ```bash
-curl -i http://kong.example/echo --resolve kong.example:80:$PROXY_IP
+curl -i http://kong.example/echo --connect-to kong.example:80:${PROXY_IP##http://}
 ```
 Response:
 ```text
@@ -202,7 +202,7 @@ service/echo annotated
 Kong will now enforce a rate limit to requests proxied to this Service:
 
 ```bash
-curl -i http://kong.example/echo --resolve kong.example:80:$PROXY_IP
+curl -i http://kong.example/echo --connect-to kong.example:80:${PROXY_IP##http://}
 ```
 Response:
 ```text


### PR DESCRIPTION
### Description

Replace `--resolve` flag with `--connect-to` flag on curl commands to allow use of target host and port, per curl manual [curl manual](https://curl.se/docs/manpage.html).

### Testing instructions

Netlify link: <!-- Netlify will generate a preview link after PR is opened. Add links to your edited content here. -->


### Checklist 

- [ ] Review label added <!-- (see below) -->
- [ ] PR pointed to correct branch (`main` for immediate publishing, or a release branch: e.g. `release/gateway-3.2`, `release/deck-1.17`)


<!-- !!! Only Kong employees can add labels due to a GitHub limitation. If you're an OSS contributor, thank you! The maintainers will label this PR for you !!! -->

<!-- When raising a pull request, indicate what type of review you need with one of the following labels:

    review:copyedit: Request for writer review.
    review:general: Review for general accuracy and presentation. Does the doc work? Does it output correctly?
    review:tech: Request for technical review for a docs platform change.
    review:sme: Request for review from an SME (engineer, PM, etc).

At least one of these labels must be applied to a PR or the build will fail.
-->

